### PR TITLE
Added configuration options, caching and Dutch to English conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RDW.configure do |config|
   #   - 'Niet geregistreerd' will be translated to 'unregistered'
   #
   # Default value: false
-  config.format_values = true
+  config.translate_values = true
 end
 ```
 Add the configuration in the `config/initializers` folder, name the file `rdw.rb` (any name will work).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It makes the following attributes available:
 * `BPM`
 * `co2_combined`
 * `fuel_type`
+* `stock_price`
 
 # Usage
 ``` ruby
@@ -30,6 +31,7 @@ require "RDW"
 
 # Notice
 There is a rate limit on this api (50,000 per month), more information can be found here: [rdw.nl](http://www.rdw.nl/Zakelijk/Paginas/Open-data.aspx).
+More details for the service can be found here: [http://www.rdw.nl/SiteCollectionDocuments/Over%20RDW/Naslagwerk/Beschrijving%20dataset%20Voertuigen.pdf].
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ RDW.configure do |config|
   # Default value: rdw_
   config.cache_prefix = 'rdw_data_'
   
-  # If set to true, Dutch values will be converted to english. 
+  # If set to true, Dutch values will be translated to english.
   # This applies to colors, fuel types and unregistered values
   # For example:
-  #   - 'ROOD' will be converted to 'red'
-  #   - 'Benzine' will be converted to 'gasoline'
-  #   - 'Niet geregistreerd' will be converted to 'unregistered'
+  #   - 'ROOD' will be translated to 'red'
+  #   - 'Benzine' will be translated to 'gasoline'
+  #   - 'Niet geregistreerd' will be translated to 'unregistered'
   #
   # Default value: false
   config.format_values = true

--- a/lib/rdw.rb
+++ b/lib/rdw.rb
@@ -55,6 +55,10 @@ module RDW
       parse("Merk")
     end
 
+    def trade_name
+      parse("Handelsbenaming")
+    end
+
     def energy_label
       parse("Zuinigheidslabel")
     end

--- a/lib/rdw.rb
+++ b/lib/rdw.rb
@@ -67,6 +67,10 @@ module RDW
       parse('Catalogusprijs')
     end
 
+    def engine_power
+      parse('Vermogen')
+    end
+
     def inspect
       "<RDW::CarInfo license_plate:'#{@license_plate}' brand:'#{brand}' fuel_type:'#{fuel_type}'>"
     end

--- a/lib/rdw.rb
+++ b/lib/rdw.rb
@@ -1,5 +1,5 @@
 require 'rdw/version'
-require 'rdw/value_converter'
+require 'rdw/value_translator'
 require 'rdw/configuration'
 require 'rdw/car_info'
 require 'open-uri'

--- a/lib/rdw.rb
+++ b/lib/rdw.rb
@@ -59,6 +59,10 @@ module RDW
       parse("Zuinigheidslabel")
     end
 
+    def stock_price
+      parse('Catalogusprijs')
+    end
+
     def inspect
       "<RDW::CarInfo license_plate:'#{@license_plate}' brand:'#{brand}' fuel_type:'#{fuel_type}'>"
     end

--- a/lib/rdw.rb
+++ b/lib/rdw.rb
@@ -82,7 +82,12 @@ module RDW
   private
 
     def parse(attribute_name)
-      @xml.xpath("//d:#{attribute_name.to_s}").text
+      begin
+        @xml.xpath("//d:#{attribute_name.to_s}").text
+      rescue
+        nil
+      end
+
     end
 
     def perform_request!

--- a/lib/rdw.rb
+++ b/lib/rdw.rb
@@ -1,98 +1,22 @@
-require "rdw/version"
-require "net/http"
-require "nokogiri"
+require 'rdw/version'
+require 'rdw/value_converter'
+require 'rdw/configuration'
+require 'rdw/car_info'
+require 'open-uri'
+require 'nokogiri'
 
 module RDW
 
-  class CarInfo
-
-    def initialize(license_plate)
-      @license_plate = license_plate
-      perform_request!
-    end
-
-    def number_of_cylinders
-      parse("Aantalcilinders").to_i
-    end
-
-    def number_of_seats
-      parse("Aantalzitplaatsen").to_i
-    end
-
-    def BPM
-      parse("BPM").to_i
-    end
-
-    def fuel_efficiency_main_road
-      parse("Brandstofverbruikbuitenweg").to_f
-    end
-
-    def fuel_efficiency_city
-      parse("Brandstofverbruikstad").to_f
-    end
-
-    def fuel_efficiency_combined
-      parse("Brandstofverbruikgecombineerd").to_f
-    end
-
-    def cylinder_capacity
-      parse("Cilinderinhoud").to_f
-    end
-
-    def co2_combined
-      parse("CO2uitstootgecombineerd").to_f
-    end
-
-    def color
-      parse("Eerstekleur")
-    end
-
-    def fuel_type
-      parse("Hoofdbrandstof")
-    end
-
-    def brand
-      parse("Merk")
-    end
-
-    def trade_name
-      parse("Handelsbenaming")
-    end
-
-    def energy_label
-      parse("Zuinigheidslabel")
-    end
-
-    def stock_price
-      parse('Catalogusprijs')
-    end
-
-    def engine_power
-      parse('Vermogen')
-    end
-
-    def inspect
-      "<RDW::CarInfo license_plate:'#{@license_plate}' brand:'#{brand}' fuel_type:'#{fuel_type}'>"
-    end
-
-    def raw_data_field(attribute_name)
-      parse(attribute_name)
-    end
-
-  private
-
-    def parse(attribute_name)
-      begin
-        @xml.xpath("//d:#{attribute_name.to_s}").text
-      rescue
-        nil
-      end
-
-    end
-
-    def perform_request!
-      response = Net::HTTP.get_response(URI("https://api.datamarket.azure.com/Data.ashx/opendata.rdw/VRTG.Open.Data/v1/KENT_VRTG_O_DAT('#{@license_plate}')"))
-      @xml = Nokogiri::XML(response.body)
-    end
+  def self.configuration
+    @configuration ||=  Configuration.new
   end
+
+  def self.configure
+    yield(configuration) if block_given?
+  end
+
+  def self.reset
+    @configuration = Configuration.new
+  end
+
 end

--- a/lib/rdw.rb
+++ b/lib/rdw.rb
@@ -67,6 +67,10 @@ module RDW
       "<RDW::CarInfo license_plate:'#{@license_plate}' brand:'#{brand}' fuel_type:'#{fuel_type}'>"
     end
 
+    def raw_data_field(attribute_name)
+      parse(attribute_name)
+    end
+
   private
 
     def parse(attribute_name)

--- a/lib/rdw/car_info.rb
+++ b/lib/rdw/car_info.rb
@@ -1,0 +1,112 @@
+module RDW
+  class CarInfo
+
+    def initialize(license_plate)
+      @license_plate = license_plate
+      perform_request!
+    end
+
+    def number_of_cylinders
+      parse('Aantalcilinders').to_i
+    end
+
+    def number_of_seats
+      parse('Aantalzitplaatsen').to_i
+    end
+
+    def bpm
+      parse('BPM').to_i
+    end
+
+    alias_method :BPM, :bpm
+
+    def fuel_efficiency_main_road
+      parse('Brandstofverbruikbuitenweg').to_f
+    end
+
+    def fuel_efficiency_city
+      parse('Brandstofverbruikstad').to_f
+    end
+
+    def fuel_efficiency_combined
+      parse('Brandstofverbruikgecombineerd').to_f
+    end
+
+    def cylinder_capacity
+      parse('Cilinderinhoud').to_f
+    end
+
+    def co2_combined
+      parse('CO2uitstootgecombineerd').to_f
+    end
+
+    def first_color
+      color = parse('Eerstekleur')
+      RDW.configuration.format_values && color != 'unknown'  ? ValueConverter.convert_color(color) : color
+    end
+
+    alias_method :color, :first_color
+
+    def second_color
+      color = parse('Tweedekleur')
+      RDW.configuration.format_values && color != 'unknown' ? ValueConverter.convert_color(color) : color
+    end
+
+    def fuel_type
+      fuel_type = parse('Hoofdbrandstof')
+      RDW.configuration.format_values && fuel_type != 'unknown' ? ValueConverter.convert_fuel_type(fuel_type) : fuel_type
+    end
+
+    def brand
+      parse('Merk')
+    end
+
+    def trade_name
+      parse('Handelsbenaming')
+    end
+
+    def energy_label
+      parse('Zuinigheidslabel')
+    end
+
+    def stock_price
+      parse('Catalogusprijs')
+    end
+
+    def engine_power
+      parse('Vermogen')
+    end
+
+    def inspect
+      "<RDW::CarInfo license_plate:'#{@license_plate}' brand:'#{brand}' fuel_type:'#{fuel_type}'>"
+    end
+
+    def raw_data_field(attribute_name)
+      parse(attribute_name)
+    end
+
+    private
+
+    def parse(attribute_name)
+      begin
+        value = @xml.xpath("//d:#{attribute_name.to_s}").text
+        RDW.configuration.format_values ? ValueConverter.convert_unknown(value) : value
+      rescue
+        nil
+      end
+    end
+
+
+    def perform_request!
+      api_url = "https://api.datamarket.azure.com/Data.ashx/opendata.rdw/VRTG.Open.Data/v1/KENT_VRTG_O_DAT('#{@license_plate}')"
+      if RDW.configuration.cache.nil?
+        response = URI.parse(api_url).read
+      else
+        response = RDW.configuration.cache.fetch(RDW.configuration.cache_prefix.to_s + @license_plate.to_s.upcase) do
+          URI.parse(api_url).read
+        end
+      end
+      @xml = Nokogiri::XML(response)
+    end
+  end
+end

--- a/lib/rdw/car_info.rb
+++ b/lib/rdw/car_info.rb
@@ -42,19 +42,19 @@ module RDW
 
     def first_color
       color = parse('Eerstekleur')
-      RDW.configuration.format_values && color != 'unregistered'  ? ValueConverter.convert_color(color) : color
+      RDW.configuration.translate_values && color != 'unregistered'  ? ValueConverter.translate_color(color) : color
     end
 
     alias_method :color, :first_color
 
     def second_color
       color = parse('Tweedekleur')
-      RDW.configuration.format_values && color != 'unregistered' ? ValueConverter.convert_color(color) : color
+      RDW.configuration.translate_values && color != 'unregistered' ? ValueConverter.translate_color(color) : color
     end
 
     def fuel_type
       fuel_type = parse('Hoofdbrandstof')
-      RDW.configuration.format_values && fuel_type != 'unregistered' ? ValueConverter.convert_fuel_type(fuel_type) : fuel_type
+      RDW.configuration.translate_values && fuel_type != 'unregistered' ? ValueConverter.translate_fuel_type(fuel_type) : fuel_type
     end
 
     def brand
@@ -90,7 +90,7 @@ module RDW
     def parse(attribute_name)
       begin
         value = @xml.xpath("//d:#{attribute_name.to_s}").text
-        RDW.configuration.format_values ? ValueConverter.convert_unregistered(value) : value
+        RDW.configuration.translate_values ? ValueConverter.translate_unregistered(value) : value
       rescue
         nil
       end

--- a/lib/rdw/car_info.rb
+++ b/lib/rdw/car_info.rb
@@ -42,19 +42,19 @@ module RDW
 
     def first_color
       color = parse('Eerstekleur')
-      RDW.configuration.format_values && color != 'unknown'  ? ValueConverter.convert_color(color) : color
+      RDW.configuration.format_values && color != 'unregistered'  ? ValueConverter.convert_color(color) : color
     end
 
     alias_method :color, :first_color
 
     def second_color
       color = parse('Tweedekleur')
-      RDW.configuration.format_values && color != 'unknown' ? ValueConverter.convert_color(color) : color
+      RDW.configuration.format_values && color != 'unregistered' ? ValueConverter.convert_color(color) : color
     end
 
     def fuel_type
       fuel_type = parse('Hoofdbrandstof')
-      RDW.configuration.format_values && fuel_type != 'unknown' ? ValueConverter.convert_fuel_type(fuel_type) : fuel_type
+      RDW.configuration.format_values && fuel_type != 'unregistered' ? ValueConverter.convert_fuel_type(fuel_type) : fuel_type
     end
 
     def brand
@@ -90,12 +90,11 @@ module RDW
     def parse(attribute_name)
       begin
         value = @xml.xpath("//d:#{attribute_name.to_s}").text
-        RDW.configuration.format_values ? ValueConverter.convert_unknown(value) : value
+        RDW.configuration.format_values ? ValueConverter.convert_unregistered(value) : value
       rescue
         nil
       end
     end
-
 
     def perform_request!
       api_url = "https://api.datamarket.azure.com/Data.ashx/opendata.rdw/VRTG.Open.Data/v1/KENT_VRTG_O_DAT('#{@license_plate}')"

--- a/lib/rdw/configuration.rb
+++ b/lib/rdw/configuration.rb
@@ -1,0 +1,24 @@
+module RDW
+
+  class Configuration
+
+    # Configure a cache to be used. Leave nil if no cache should be used.
+    attr_accessor :cache
+
+    # Cache key prefix
+    attr_accessor :cache_prefix
+
+    # Set to true if you want values to be returned in english.
+    # Example for colors: 'ROOD' will return 'red'.
+    # Example for fuel types: 'Benzine' will return 'gasoline'.
+    # 'Niet geregistreerd' (which means that no value registered in the RDW database) will return 'unknown'.
+    attr_accessor :format_values
+
+    def initialize
+      @cache = nil
+      @cache_prefix = 'rdw_'
+      @format_values = false
+    end
+
+  end
+end

--- a/lib/rdw/configuration.rb
+++ b/lib/rdw/configuration.rb
@@ -9,19 +9,19 @@ module RDW
     # Default value: rdw_
     attr_accessor :cache_prefix
 
-    # If set to true, Dutch values will be converted to english.
+    # If set to true, Dutch values will be translated to english.
     # This applies to colors, fuel types and unregistered values
     # For example:
-    #   - 'ROOD' will be converted to 'red'
-    #   - 'Benzine' will be converted to 'gasoline'
-    #   - 'Niet geregistreerd' will be converted to 'unregistered'
+    #   - 'ROOD' will be translated to 'red'
+    #   - 'Benzine' will be translated to 'gasoline'
+    #   - 'Niet geregistreerd' will be translated to 'unregistered'
     # Default value: false
-    attr_accessor :format_values
+    attr_accessor :translate_values
 
     def initialize
       @cache = nil
       @cache_prefix = 'rdw_'
-      @format_values = false
+      @translate_values = false
     end
 
   end

--- a/lib/rdw/configuration.rb
+++ b/lib/rdw/configuration.rb
@@ -5,13 +5,17 @@ module RDW
     # Configure a cache to be used. Leave nil if no cache should be used.
     attr_accessor :cache
 
-    # Cache key prefix
+    # If you are using the cache you can set a custom prefix for cache keys.
+    # Default value: rdw_
     attr_accessor :cache_prefix
 
-    # Set to true if you want values to be returned in english.
-    # Example for colors: 'ROOD' will return 'red'.
-    # Example for fuel types: 'Benzine' will return 'gasoline'.
-    # 'Niet geregistreerd' (which means that no value registered in the RDW database) will return 'unknown'.
+    # If set to true, Dutch values will be converted to english.
+    # This applies to colors, fuel types and unregistered values
+    # For example:
+    #   - 'ROOD' will be converted to 'red'
+    #   - 'Benzine' will be converted to 'gasoline'
+    #   - 'Niet geregistreerd' will be converted to 'unregistered'
+    # Default value: false
     attr_accessor :format_values
 
     def initialize

--- a/lib/rdw/value_converter.rb
+++ b/lib/rdw/value_converter.rb
@@ -49,10 +49,10 @@ module RDW
       new_color ? new_color : color
     end
 
-    # Returns 'unknown' instead of 'Niet geregistreerd'
-    def self.convert_unknown(value)
+    # Returns 'unregistered' instead of 'Niet geregistreerd'
+    def self.convert_unregistered(value)
       if value.downcase == 'niet geregistreerd'
-        return 'unknown'
+        return 'unregistered'
       end
       value
     end

--- a/lib/rdw/value_converter.rb
+++ b/lib/rdw/value_converter.rb
@@ -1,0 +1,66 @@
+module RDW
+
+  class ValueConverter
+
+    # Colors as expected from the RDW api converted to english names.
+    @colors = {
+        'oranje' => 'orange',
+        'roze' => 'pink',
+        'rood' => 'red',
+        'wit' => 'white',
+        'blauw' => 'blue',
+        'groen' => 'green',
+        'geel' => 'yellow',
+        'grijs' => 'gray',
+        'bruin' => 'brown',
+        'creme' => 'cream',
+        'paars' => 'purple',
+        'zwart' => 'black',
+        'diversen' => 'miscellaneous'
+    }
+
+    # Fuel types as expected from the RDW api converted to english names.
+    @fuel_types = {
+        'benzine' => 'gasoline',
+        'liquified natural gas' => 'lng',
+        'lng' => 'lng',
+        'diesel' => 'diesel',
+        'elektriciteit' => 'electric',
+        'liquified petrol gas' => 'lpg',
+        'lpg' => 'lpg',
+        'compressed natural gas' => 'cng',
+        'cng' => 'cng',
+        'waterstof' => 'hydrogen',
+        'alcohol' => 'alcohol'
+    }
+
+
+    # Return the given +fuel_type+ in english. If no fuel_type is found, the original fuel_type will be returned.
+    def self.convert_fuel_type(fuel_type)
+      return nil if @fuel_types[fuel_type.downcase].nil?
+      new_fuel_type = @fuel_types[fuel_type.downcase]
+      new_fuel_type ? new_fuel_type : fuel_type
+    end
+
+    # Return the given +color+ in english. If no color is found, the original color will be returned.
+    def self.convert_color(color)
+      return nil if @colors[color.downcase].nil?
+      new_color = @colors[color.downcase]
+      new_color ? new_color : color
+    end
+
+    # Returns 'unknown' instead of 'Niet geregistreerd'
+    def self.convert_unknown(value)
+      if value.downcase == 'niet geregistreerd'
+        return 'unknown'
+      end
+      value
+    end
+
+  end
+
+
+
+
+
+end

--- a/lib/rdw/value_translator.rb
+++ b/lib/rdw/value_translator.rb
@@ -19,7 +19,7 @@ module RDW
         'diversen' => 'miscellaneous'
     }
 
-    # Fuel types as expected from the RDW api converted to english names.
+    # Fuel types as expected from the RDW api translated to english names.
     @fuel_types = {
         'benzine' => 'gasoline',
         'liquified natural gas' => 'lng',
@@ -36,21 +36,21 @@ module RDW
 
 
     # Return the given +fuel_type+ in english. If no fuel_type is found, the original fuel_type will be returned.
-    def self.convert_fuel_type(fuel_type)
+    def self.translate_fuel_type(fuel_type)
       return nil if @fuel_types[fuel_type.downcase].nil?
       new_fuel_type = @fuel_types[fuel_type.downcase]
       new_fuel_type ? new_fuel_type : fuel_type
     end
 
     # Return the given +color+ in english. If no color is found, the original color will be returned.
-    def self.convert_color(color)
+    def self.translate_color(color)
       return nil if @colors[color.downcase].nil?
       new_color = @colors[color.downcase]
       new_color ? new_color : color
     end
 
     # Returns 'unregistered' instead of 'Niet geregistreerd'
-    def self.convert_unregistered(value)
+    def self.translate_unregistered(value)
       if value.downcase == 'niet geregistreerd'
         return 'unregistered'
       end

--- a/lib/rdw/version.rb
+++ b/lib/rdw/version.rb
@@ -1,3 +1,3 @@
 module Rdw
-  VERSION = "1.0.3"
+  VERSION = "1.1.0"
 end

--- a/lib/rdw/version.rb
+++ b/lib/rdw/version.rb
@@ -1,3 +1,3 @@
 module Rdw
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/lib/rdw/version.rb
+++ b/lib/rdw/version.rb
@@ -1,3 +1,3 @@
 module Rdw
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/rdw/version.rb
+++ b/lib/rdw/version.rb
@@ -1,3 +1,3 @@
 module Rdw
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/rdw_car_info_spec.rb
+++ b/spec/rdw_car_info_spec.rb
@@ -19,10 +19,34 @@ describe RDW::CarInfo do
     its("cylinder_capacity") { should eq 5999.0 }
     its("co2_combined") { should eq 490.0 }
     its("color") { should eq "ROOD" }
+    its("first_color") { should eq "ROOD" }
+    its("second_color") { should eq "Niet geregistreerd" }
     its("fuel_type") { should eq "Benzine" }
     its("brand") { should eq "FERRARI" }
     its("energy_label") { should eq "G" }
     its("inspect") { should eq "<RDW::CarInfo license_plate:'9KJT45' brand:'FERRARI' fuel_type:'Benzine'>" }
+
+  end
+
+  context "use formatted values, given the license plate of a Ferrari" do
+
+    before :each do
+      RDW.configure do |config|
+        config.format_values = true
+      end
+    end
+
+    let(:license_plate) { "9KJT45" }
+    before { VCR.eject_cassette }
+    before { VCR.insert_cassette("ferrari_9KJT45") }
+    subject { described_class.new(license_plate) }
+
+    it { should be_a RDW::CarInfo }
+
+    its("first_color") { should eq "red" }
+    its("second_color") { should eq "unknown" }
+    its("fuel_type") { should eq "gasoline" }
+
   end
 
   context "given the license plate of a New Beetle" do
@@ -69,6 +93,10 @@ describe RDW::CarInfo do
     its("brand") { should eq "VOLKSWAGEN" }
     its("energy_label") { should eq "" }
     its("inspect") { should eq "<RDW::CarInfo license_plate:'67YA03' brand:'VOLKSWAGEN' fuel_type:'LPG (Liquified Petrol Gas)'>" }
+  end
+
+  after :each do
+    RDW.reset
   end
 
 end

--- a/spec/rdw_car_info_spec.rb
+++ b/spec/rdw_car_info_spec.rb
@@ -28,11 +28,11 @@ describe RDW::CarInfo do
 
   end
 
-  context "use formatted values, given the license plate of a Ferrari" do
+  context "use translated values, given the license plate of a Ferrari" do
 
     before :each do
       RDW.configure do |config|
-        config.format_values = true
+        config.translate_values = true
       end
     end
 

--- a/spec/rdw_car_info_spec.rb
+++ b/spec/rdw_car_info_spec.rb
@@ -44,7 +44,7 @@ describe RDW::CarInfo do
     it { should be_a RDW::CarInfo }
 
     its("first_color") { should eq "red" }
-    its("second_color") { should eq "unknown" }
+    its("second_color") { should eq "unregistered" }
     its("fuel_type") { should eq "gasoline" }
 
   end


### PR DESCRIPTION
Hi,

I have used your gem in a project, but missed some features. So I added them myself.

New features to this gem:
* Option to convert Dutch colors, fuel types, and 'niet geregistreerd' to English. I also added a test for this.
* Option to use a cache.
* Cache, cache prefix and if Dutch values should be converted to English can be configured. See readme.

Other changes:
* Moved CarInfo class into a separate file.
* Added `first_color` (with `color` as an alias) and `second_color` attributes.
* I changed the `BPM` method name to lowercase, to follow Rails method naming convention. I added an alias `BPM` for this, so it is still backwards compatible.
* Using open-uri instead of net/http to read the RDW API.

This update should be backwards compatible, all original tests still pass. However I don't know how to test the caching feature with a test case. I use a test application to try it, it should work.

Let me know what you think.